### PR TITLE
Change large integer implementation to ubig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,12 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "az"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822d7d63e0c0260a050f6b1f0d316f5c79b9eab830aca526ed904e1011bd64ca"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +74,12 @@ dependencies = [
  "textwrap",
  "unicode-width",
 ]
+
+[[package]]
+name = "const_fn_assert"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d614f23f34f7b5165a77dc1591f497e2518f9cec4b4f4b92bfc4dc6cf7a190"
 
 [[package]]
 name = "criterion"
@@ -191,16 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "gmp-mpfr-sys"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed49cf8abf2378b5c5b53b950917c683858b186c16c6017593e0213a8db78dcc"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +203,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ibig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c524ff730eb3edb19b3852a278f5db94f3f0c1589a922fe59c163529009ded"
+dependencies = [
+ "cfg-if",
+ "const_fn_assert",
+ "num-traits",
+ "rand",
+ "static_assertions",
 ]
 
 [[package]]
@@ -314,8 +317,8 @@ name = "parallel-factorial"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "ibig",
  "rayon",
- "rug",
 ]
 
 [[package]]
@@ -365,6 +368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,17 +430,6 @@ name = "regex-syntax"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
-
-[[package]]
-name = "rug"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f75e07492c4d17d12f226d17e689fdb698db7a1e875fca0fac15626283bf24"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
-]
 
 [[package]]
 name = "rustc_version"
@@ -506,6 +513,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 lto = true
 
 [dependencies]
-rug = "1.12.0"
+ibig = "0.3.4"
 rayon = "1.5.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+use ibig::{UBig, ubig};
 use rayon::prelude::*;
-use rug::Integer;
 
 /// Calculate a factorial number from an integer.
 pub fn factorial(n: u64) -> String {
@@ -10,18 +10,18 @@ pub fn factorial(n: u64) -> String {
         return single_threaded_factorial(n);
     }
 
-    let mut result: Vec<Integer> = vec
+    let mut result: Vec<UBig> = vec
         .chunks(offset)
         .par_bridge()
         .into_par_iter()
         .map(|range| {
-            let mut acc = Integer::from(1);
+            let mut acc = ubig!(1);
             for &number in range {
                 acc *= number;
             }
             acc
         })
-        .collect::<Vec<Integer>>();
+        .collect::<Vec<UBig>>();
 
     let mut acc = result.pop().unwrap();
 
@@ -33,7 +33,7 @@ pub fn factorial(n: u64) -> String {
 }
 
 fn single_threaded_factorial(n: u64) -> String {
-    let mut acc = Integer::from(n);
+    let mut acc = ubig!(n);
     for index in 1..n {
         acc *= index;
     }


### PR DESCRIPTION
# Description
Performance suffers here, but the implementation is pure rust. This means it should be possible to compile this project to wasm easily, so for me personally this is an easy trade-off to make.

## Performance
- Doing 1,000,000! used to take just over 1 sec with gmp/rug.
- with ibig, this now takes just over 5 seconds.

There's definitely a performance cost we're paying here. Kinda worth it tho, wasm is pretty sweet!