### PR TITLE
fix: incorrect use of macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parallel-factorial"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "ibig",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parallel-factorial"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Gary Moore <madmangaz@gmail.com>"]
 license = "MIT"
 description = "Simple, fast, parallel factorial calculator."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub fn factorial(n: u64) -> String {
 }
 
 fn single_threaded_factorial(n: u64) -> String {
-    let mut acc = ubig!(n);
+    let mut acc = UBig::from(n);
     for index in 1..n {
         acc *= index;
     }


### PR DESCRIPTION
Update to use `UInt::from()` rather than `uint!()`. `uint!()` is only for compile time integers, that is integers in the binary's data rather than something from a variable.

resolves #2 